### PR TITLE
chore: Return config with camelcased keys only

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 const fs = require('fs');
 const path = require('path');
 const camelcase = require('camelcase');
-const decamelize = require('decamelize');
 const findUp = require('find-up');
 
 const standardConfigFiles = [
@@ -14,12 +13,10 @@ const standardConfigFiles = [
 	'nyc.config.js'
 ];
 
-function copyConfigFields(config) {
+function camelcasedConfig(config) {
 	const results = {};
 	for (const [field, value] of Object.entries(config)) {
-		results[field] = value;
 		results[camelcase(field)] = value;
-		results[decamelize(field, '-')] = value;
 	}
 
 	return results;
@@ -71,8 +68,8 @@ function loadNycConfig(options = {}) {
 	}
 
 	const config = {
-		...copyConfigFields(pkgConfig),
-		...copyConfigFields(actualLoad(configFile))
+		...camelcasedConfig(pkgConfig),
+		...camelcasedConfig(actualLoad(configFile))
 	};
 
 	const arrayFields = ['require', 'extension', 'exclude', 'include'];

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 	"homepage": "https://github.com/istanbuljs/load-nyc-config#readme",
 	"dependencies": {
 		"camelcase": "^5.3.1",
-		"decamelize": "^3.2.0",
 		"find-up": "^4.0.0",
 		"js-yaml": "^3.13.1"
 	},

--- a/tap-snapshots/test-basic.js-TAP.test.js
+++ b/tap-snapshots/test-basic.js-TAP.test.js
@@ -24,11 +24,8 @@ Object {
 
 exports[`test/basic.js TAP camel-decamel > must match snapshot 1`] = `
 Object {
-  "exclude-after-remap": false,
-  "exclude-node-modules": false,
   "excludeAfterRemap": false,
   "excludeNodeModules": false,
-  "skip-full": true,
   "skipFull": true,
 }
 `


### PR DESCRIPTION
This will make it easier to support `extends` functionality.