### PR TITLE
fix: Add `cwd` to returned config object

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,6 +118,7 @@ async function loadNycConfig(options = {}) {
 	}
 
 	const config = {
+		cwd,
 		...(await applyExtends(pkgConfig, path.join(cwd, 'package.json'))),
 		...(await applyExtends(await actualLoad(configFile), configFile))
 	};

--- a/tap-snapshots/test-basic.js-TAP.test.js
+++ b/tap-snapshots/test-basic.js-TAP.test.js
@@ -7,6 +7,7 @@
 'use strict'
 exports[`test/basic.js TAP array-field-fixup > must match snapshot 1`] = `
 Object {
+  "cwd": "array-field-fixup",
   "exclude": Array [
     "test.js",
   ],
@@ -24,6 +25,7 @@ Object {
 
 exports[`test/basic.js TAP camel-decamel > must match snapshot 1`] = `
 Object {
+  "cwd": "camel-decamel",
   "excludeAfterRemap": false,
   "excludeNodeModules": false,
   "skipFull": true,
@@ -33,24 +35,28 @@ Object {
 exports[`test/basic.js TAP esm nyc-config-js-type-module > must match snapshot 1`] = `
 Object {
   "all": false,
+  "cwd": "nyc-config-js-type-module",
 }
 `
 
 exports[`test/basic.js TAP esm nyc-config-mjs > must match snapshot 1`] = `
 Object {
   "all": false,
+  "cwd": "nyc-config-mjs",
 }
 `
 
 exports[`test/basic.js TAP extends > must match snapshot 1`] = `
 Object {
   "all": false,
+  "cwd": "extends",
 }
 `
 
 exports[`test/basic.js TAP extends-array > must match snapshot 1`] = `
 Object {
   "all": false,
+  "cwd": "extends-array",
   "excludeNodeModules": true,
 }
 `
@@ -58,63 +64,82 @@ Object {
 exports[`test/basic.js TAP extends-array-empty > must match snapshot 1`] = `
 Object {
   "all": true,
+  "cwd": "extends-array-empty",
+}
+`
+
+exports[`test/basic.js TAP found package.json cwd from subdir > must match snapshot 1`] = `
+Object {
+  "all": false,
+  "cwd": "nycrc-json",
 }
 `
 
 exports[`test/basic.js TAP no package.json > explicit .nycrc 1`] = `
 Object {
   "all": false,
+  "cwd": "root:;",
 }
 `
 
 exports[`test/basic.js TAP no package.json > no config 1`] = `
-Object {}
+Object {
+  "cwd": "root:;",
+}
 `
 
 exports[`test/basic.js TAP no-config-file > must match snapshot 1`] = `
 Object {
   "all": true,
+  "cwd": "no-config-file",
 }
 `
 
 exports[`test/basic.js TAP nyc-config-async > must match snapshot 1`] = `
 Object {
   "all": false,
+  "cwd": "nyc-config-async",
 }
 `
 
 exports[`test/basic.js TAP nyc-config-cjs > must match snapshot 1`] = `
 Object {
   "all": false,
+  "cwd": "nyc-config-cjs",
 }
 `
 
 exports[`test/basic.js TAP nyc-config-js > must match snapshot 1`] = `
 Object {
   "all": false,
+  "cwd": "nyc-config-js",
 }
 `
 
 exports[`test/basic.js TAP nycrc-json > must match snapshot 1`] = `
 Object {
   "all": false,
+  "cwd": "nycrc-json",
 }
 `
 
 exports[`test/basic.js TAP nycrc-no-ext > must match snapshot 1`] = `
 Object {
   "all": false,
+  "cwd": "nycrc-no-ext",
 }
 `
 
 exports[`test/basic.js TAP nycrc-yaml > must match snapshot 1`] = `
 Object {
   "all": false,
+  "cwd": "nycrc-yaml",
 }
 `
 
 exports[`test/basic.js TAP nycrc-yml > must match snapshot 1`] = `
 Object {
   "all": false,
+  "cwd": "nycrc-yml",
 }
 `

--- a/tap-snapshots/test-env-nyc-cwd.js-TAP.test.js
+++ b/tap-snapshots/test-env-nyc-cwd.js-TAP.test.js
@@ -8,5 +8,6 @@
 exports[`test/env-nyc-cwd.js TAP env-nyc-cwd > must match snapshot 1`] = `
 Object {
   "all": true,
+  "cwd": "no-config-file",
 }
 `

--- a/tap-snapshots/test-process-cwd.js-TAP.test.js
+++ b/tap-snapshots/test-process-cwd.js-TAP.test.js
@@ -8,5 +8,6 @@
 exports[`test/process-cwd.js TAP process-cwd > must match snapshot 1`] = `
 Object {
   "all": true,
+  "cwd": "no-config-file",
 }
 `

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,5 +1,6 @@
+const path = require('path');
 const t = require('tap');
-const {fixturePath, basicTest, hasImport, hasESM} = require('./helpers');
+const {fixturePath, sanitizeConfig, basicTest, hasImport, hasESM} = require('./helpers');
 const {loadNycConfig} = require('..');
 
 t.test('options.nycrcPath points to non-existent file', async t => {
@@ -46,11 +47,16 @@ t.test('extends failures', async t => {
 });
 
 t.test('no package.json', async t => {
-	const cwd = '/';
+	const cwd = path.resolve('/');
 	const nycrcPath = fixturePath('nycrc-no-ext', '.nycrc');
 
-	t.matchSnapshot(await loadNycConfig({cwd}), 'no config');
-	t.matchSnapshot(await loadNycConfig({cwd, nycrcPath}), 'explicit .nycrc');
+	t.matchSnapshot(sanitizeConfig(await loadNycConfig({cwd})), 'no config');
+	t.matchSnapshot(sanitizeConfig(await loadNycConfig({cwd, nycrcPath})), 'explicit .nycrc');
+});
+
+t.test('found package.json cwd from subdir', async t => {
+	const cwd = fixturePath('nycrc-json', 'subdir');
+	t.matchSnapshot(sanitizeConfig(await loadNycConfig({cwd})));
 });
 
 if (hasImport) {

--- a/test/env-nyc-cwd.js
+++ b/test/env-nyc-cwd.js
@@ -1,12 +1,12 @@
 const t = require('tap');
-const {fixturePath} = require('./helpers');
+const {fixturePath, sanitizeConfig} = require('./helpers');
 const {loadNycConfig} = require('..');
 
 t.test('env-nyc-cwd', async t => {
 	const saved = process.env.NYC_CWD;
 	process.env.NYC_CWD = fixturePath('no-config-file');
 
-	t.matchSnapshot(await loadNycConfig());
+	t.matchSnapshot(sanitizeConfig(await loadNycConfig()));
 
 	process.env.NYC_CWD = saved;
 });

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -5,10 +5,21 @@ function fixturePath(...args) {
 	return path.join(__dirname, '..', 'fixtures', ...args);
 }
 
+function sanitizeConfig(config) {
+	if (config.cwd === path.resolve('/')) {
+		config.cwd = 'root:;';
+	} else {
+		config.cwd = path.basename(config.cwd);
+	}
+
+	return config;
+}
+
 async function basicTest(t) {
 	const cwd = fixturePath(t.name);
+	const config = await loadNycConfig({cwd});
 
-	t.matchSnapshot(await loadNycConfig({cwd}));
+	t.matchSnapshot(sanitizeConfig(config));
 }
 
 function canImport() {
@@ -35,6 +46,7 @@ async function hasESM() {
 
 module.exports = {
 	fixturePath,
+	sanitizeConfig,
 	basicTest,
 	hasImport: canImport(),
 	hasESM

--- a/test/process-cwd.js
+++ b/test/process-cwd.js
@@ -1,5 +1,5 @@
 const t = require('tap');
-const {fixturePath} = require('./helpers');
+const {fixturePath, sanitizeConfig} = require('./helpers');
 const {loadNycConfig} = require('..');
 
 t.test('process-cwd', async t => {
@@ -8,7 +8,7 @@ t.test('process-cwd', async t => {
 
 	process.chdir(fixturePath('no-config-file'));
 
-	t.matchSnapshot(await loadNycConfig());
+	t.matchSnapshot(sanitizeConfig(await loadNycConfig()));
 
 	process.env.NYC_CWD = saved;
 });


### PR DESCRIPTION
This is important if the package.json is found in a parent directory
of the `cwd` option.