### PR TITLE
fix: Remove support for loading .js config under `type: 'module'`

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,5 +1,6 @@
 {
 	"test-ignore": "helpers",
 	"esm": false,
+	"100": true,
 	"nyc-arg": "--nycrc-path=nyc-settings.js"
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
   - osx
 node_js:
-  - "node"
+  - 13
+  - 12
   - 10
   - 8

--- a/index.js
+++ b/index.js
@@ -19,18 +19,6 @@ const standardConfigFiles = [
 	'nyc.config.mjs'
 ];
 
-async function moduleLoader(file) {
-	try {
-		return require(file);
-	} catch (error) {
-		if (error.code !== 'ERR_REQUIRE_ESM') {
-			throw error;
-		}
-
-		return require('./load-esm')(file);
-	}
-}
-
 function camelcasedConfig(config) {
 	const results = {};
 	for (const [field, value] of Object.entries(config)) {
@@ -64,10 +52,11 @@ async function actualLoad(configFile) {
 	const configExt = path.extname(configFile).toLowerCase();
 	switch (configExt) {
 		case '.js':
-		case '.mjs':
-			return moduleLoader(configFile);
 		case '.cjs':
 			return require(configFile);
+		/* istanbul ignore next: coverage for 13.2.0+ is shown in load-esm.js */
+		case '.mjs':
+			return require('./load-esm')(configFile);
 		case '.yml':
 		case '.yaml':
 			return require('js-yaml').load(await readFile(configFile, 'utf8'));

--- a/load-esm.js
+++ b/load-esm.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const {pathToFileURL} = require('url');
+
 module.exports = async filename => {
-	const mod = await import(filename);
+	const mod = await import(pathToFileURL(filename));
 	if ('default' in mod === false) {
 		throw new Error(`${filename} has no default export`);
 	}

--- a/nyc-settings.js
+++ b/nyc-settings.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const {hasImport} = require('./test/helpers');
+const {hasESM} = require('./test/helpers');
 
 const include = [
 	'index.js'
 ];
 
-if (hasImport) {
+if (hasESM) {
 	include.push('load-esm.js');
 }
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"resolve-from": "^5.0.0"
 	},
 	"devDependencies": {
+		"semver": "^6.3.0",
 		"standard-version": "^7.0.0",
 		"tap": "^14.6.5",
 		"xo": "^0.25.3"

--- a/tap-snapshots/test-basic.js-TAP.test.js
+++ b/tap-snapshots/test-basic.js-TAP.test.js
@@ -32,20 +32,6 @@ Object {
 }
 `
 
-exports[`test/basic.js TAP esm nyc-config-js-type-module > must match snapshot 1`] = `
-Object {
-  "all": false,
-  "cwd": "nyc-config-js-type-module",
-}
-`
-
-exports[`test/basic.js TAP esm nyc-config-mjs > must match snapshot 1`] = `
-Object {
-  "all": false,
-  "cwd": "nyc-config-mjs",
-}
-`
-
 exports[`test/basic.js TAP extends > must match snapshot 1`] = `
 Object {
   "all": false,
@@ -113,6 +99,13 @@ exports[`test/basic.js TAP nyc-config-js > must match snapshot 1`] = `
 Object {
   "all": false,
   "cwd": "nyc-config-js",
+}
+`
+
+exports[`test/basic.js TAP nyc-config-mjs > must match snapshot 1`] = `
+Object {
+  "all": false,
+  "cwd": "nyc-config-mjs",
 }
 `
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const t = require('tap');
-const {fixturePath, sanitizeConfig, basicTest, hasImport, hasESM} = require('./helpers');
+const {fixturePath, sanitizeConfig, basicTest, hasESM} = require('./helpers');
 const {loadNycConfig} = require('..');
 
 t.test('options.nycrcPath points to non-existent file', async t => {
@@ -32,7 +32,7 @@ t.test('extends failures', async t => {
 		'invalid.cjs': /Unexpected identifier/,
 		'missing.json': /Could not resolve configuration file/
 	};
-	if (hasImport && await hasESM()) {
+	if (hasESM) {
 		files['invalid.mjs'] = /has no default export/;
 	}
 
@@ -59,16 +59,6 @@ t.test('found package.json cwd from subdir', async t => {
 	t.matchSnapshot(sanitizeConfig(await loadNycConfig({cwd})));
 });
 
-if (hasImport) {
-	t.test('esm', async t => {
-		if (await hasESM()) {
-			if (process.versions.node.split('.')[0] >= 12) {
-				await t.test('nyc-config-js-type-module', basicTest);
-			}
-
-			await t.test('nyc-config-mjs', basicTest);
-		} else {
-			t.pass('we have import but it doesn\'t support ES modules');
-		}
-	});
+if (hasESM) {
+	t.test('nyc-config-mjs', basicTest);
 }

--- a/test/fixtures/nyc-config-js-type-module/nyc.config.js
+++ b/test/fixtures/nyc-config-js-type-module/nyc.config.js
@@ -1,3 +1,0 @@
-export default {
-	all: false
-};

--- a/test/fixtures/nyc-config-js-type-module/package.json
+++ b/test/fixtures/nyc-config-js-type-module/package.json
@@ -1,6 +1,0 @@
-{
-	"type": "module",
-	"nyc": {
-		"all": true
-	}
-}

--- a/test/helpers/esm-tester.mjs
+++ b/test/helpers/esm-tester.mjs
@@ -1,1 +1,0 @@
-export default 'pass';

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,8 +1,11 @@
 const path = require('path');
+const semver = require('semver');
 const {loadNycConfig} = require('../..');
 
+const hasESM = semver.gte(process.versions.node, '13.2.0');
+
 function fixturePath(...args) {
-	return path.join(__dirname, '..', 'fixtures', ...args);
+	return path.resolve(__dirname, '..', 'fixtures', ...args);
 }
 
 function sanitizeConfig(config) {
@@ -22,32 +25,9 @@ async function basicTest(t) {
 	t.matchSnapshot(sanitizeConfig(config));
 }
 
-function canImport() {
-	try {
-		return typeof require('../../load-esm') === 'function';
-	} catch (_) {
-		return false;
-	}
-}
-
-async function hasESM() {
-	try {
-		const loader = require('../../load-esm');
-		try {
-			await loader(require.resolve('./esm-tester.mjs'));
-			return true;
-		} catch (_) {
-			return false;
-		}
-	} catch (_) {
-		return false;
-	}
-}
-
 module.exports = {
 	fixturePath,
 	sanitizeConfig,
 	basicTest,
-	hasImport: canImport(),
 	hasESM
 };


### PR DESCRIPTION
It is not possible to detect if this is safe and protecting CJS users is
currently a priority.  Users who want to provide ESM configuration will
need to use `nyc.config.mjs`.