### PR TITLE
feat: Create `isLoading` function to help avoid circular load attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ defaults.  These options can be overridden by an nycrc if found.  Arrays are not
 so if `package.json` sets `"require": ["@babel/register"]` and `.nycrc` sets `"require": ["esm"]`
 the effective require setting will only include `"esm"`.
 
+## isLoading
+
+```js
+const {isLoading} = require('@istanbuljs/load-nyc-config');
+
+console.log(isLoading());
+```
+
+In some cases source transformation hooks can get installed before the configuration is
+loaded.  This allows hooks to ignore source loads that occur during configuration load.
+
 ## `@istanbuljs/load-nyc-config` for enterprise
 
 Available as part of the Tidelift Subscription.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
 		],
 		"rules": {
 			"require-atomic-updates": 0,
-			"capitalized-comments": 0
+			"capitalized-comments": 0,
+			"unicorn/import-index": 0,
+			"import/extensions": 0,
+			"import/no-useless-path-segments": 0
 		}
 	}
 }

--- a/test/fixtures/nyc-config-js-type-module/nyc.config.js
+++ b/test/fixtures/nyc-config-js-type-module/nyc.config.js
@@ -1,3 +1,7 @@
+import loadNycConfig from '../../../index.js';
+
+const {isLoading} = loadNycConfig;
+
 export default {
-	all: false
+	all: !isLoading()
 };

--- a/test/fixtures/nyc-config-js/nyc.config.js
+++ b/test/fixtures/nyc-config-js/nyc.config.js
@@ -1,3 +1,5 @@
 'use strict';
 
-module.exports = {all: false};
+const {isLoading} = require('../../../index.js');
+
+module.exports = {all: !isLoading()};


### PR DESCRIPTION
This is needed by `@istanbuljs/esm-loader-hook`.