### PR TITLE
Major package upgrade js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"camelcase": "^5.3.1",
 		"find-up": "^4.1.0",
 		"get-package-type": "^0.1.0",
-		"js-yaml": "^3.13.1",
+		"js-yaml": "^4.1.1",
 		"resolve-from": "^5.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Lets start with the obvious upgrade, the `js-yaml` security vulnerability (production dependency).

I tried running the test.. Gave error (I think I blame `xo` from the `pretest` step?):

```sh
npm test        

> @istanbuljs/load-nyc-config@1.1.0 pretest
> xo

TypeError: util.isDate is not a function
Occurred while linting /home/melroy/Documents/projects/load-nyc-config/index.js:3
...
```

But also `tap` won't run anymore...

```
./node_modules/tap/bin/run.js 
TypeError: Cannot read properties of undefined (reading 'getFileName')
    at module.exports (/home/melroy/Documents/projects/load-nyc-config/node_modules/tap/node_modules/caller-path/index.js:4:40)
```

Also you can use `fs.readFileSync` today, instead of wrapping it in `promisify` 😨 .

Fixes: https://github.com/istanbuljs/load-nyc-config/issues/22