### PR TITLE
Switch from js-yaml to yaml, updating dev dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,16 @@
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.tgz
 package
 .nyc_output
+.tap
 coverage
 node_modules

--- a/.taprc
+++ b/.taprc
@@ -1,6 +1,6 @@
 {
-	"test-ignore": "helpers",
-	"esm": false,
-	"100": true,
-	"nyc-arg": "--nycrc-path=nyc-settings.js"
+  "exclude": [
+    "test/fixtures/**",
+    "test/helpers/**"
+  ]
 }

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ async function actualLoad(configFile) {
 			return require('./load-esm')(configFile);
 		case '.yml':
 		case '.yaml':
-			return require('js-yaml').load(await readFile(configFile, 'utf8'));
+			return require('yaml').parse(await readFile(configFile, 'utf8'));
 		default:
 			return JSON.parse(await readFile(configFile, 'utf8'));
 	}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Utility function to load nyc configuration",
 	"main": "index.js",
 	"scripts": {
-		"pretest": "xo",
+		"pretest": "xo --ignore 'test/fixtures/extends/invalid.*' --ignore tap-snapshots/",
 		"test": "tap",
 		"snap": "npm test -- --snapshot",
 		"release": "standard-version"
@@ -32,16 +32,30 @@
 		"semver": "^6.3.0",
 		"standard-version": "^7.0.0",
 		"tap": "^14.10.5",
-		"xo": "^0.25.3"
+		"xo": "^1.2.3"
 	},
 	"xo": {
-		"ignores": [
-			"test/fixtures/extends/invalid.*"
-		],
 		"rules": {
+			"@stylistic/comma-dangle": 0,
+			"@stylistic/operator-linebreak": 0,
+			"arrow-body-style": 0,
 			"require-atomic-updates": 0,
 			"capitalized-comments": 0,
+			"import-x/extensions": 0,
+			"import-x/no-anonymous-default-export": 0,
+			"import-x/order": 0,
+			"logical-assignment-operators": 0,
+			"n/prefer-global/process": 0,
 			"unicorn/import-index": 0,
+			"unicorn/no-anonymous-default-export": 0,
+			"unicorn/prefer-array-flat": 0,
+			"unicorn/prefer-module": 0,
+			"unicorn/prefer-node-protocol": 0,
+			"unicorn/prefer-spread": 0,
+			"unicorn/prefer-string-replace-all": 0,
+			"unicorn/prefer-top-level-await": 0,
+			"unicorn/prevent-abbreviations": 0,
+			"unicorn/switch-case-braces": 0,
 			"import/extensions": 0,
 			"import/no-useless-path-segments": 0
 		}

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
 		"camelcase": "^5.3.1",
 		"find-up": "^4.1.0",
 		"get-package-type": "^0.1.0",
-		"js-yaml": "^3.13.1",
-		"resolve-from": "^5.0.0"
+		"resolve-from": "^5.0.0",
+		"yaml": "^2.8.1"
 	},
 	"devDependencies": {
 		"semver": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	"devDependencies": {
 		"semver": "^6.3.0",
 		"standard-version": "^7.0.0",
-		"tap": "^14.10.5",
+		"tap": "^21.1.3",
 		"xo": "^1.2.3"
 	},
 	"xo": {

--- a/tap-snapshots/test/basic.js.test.cjs
+++ b/tap-snapshots/test/basic.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/basic.js TAP array-field-fixup > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > array-field-fixup > must match snapshot 1`] = `
 Object {
   "cwd": "package-root:;test/fixtures/array-field-fixup",
   "exclude": Array [
@@ -23,7 +23,7 @@ Object {
 }
 `
 
-exports[`test/basic.js TAP camel-decamel > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > camel-decamel > must match snapshot 1`] = `
 Object {
   "cwd": "package-root:;test/fixtures/camel-decamel",
   "excludeAfterRemap": false,
@@ -32,14 +32,14 @@ Object {
 }
 `
 
-exports[`test/basic.js TAP extends > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > extends > must match snapshot 1`] = `
 Object {
   "all": false,
   "cwd": "package-root:;test/fixtures/extends",
 }
 `
 
-exports[`test/basic.js TAP extends-array > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > extends-array > must match snapshot 1`] = `
 Object {
   "all": false,
   "cwd": "package-root:;test/fixtures/extends-array",
@@ -47,111 +47,111 @@ Object {
 }
 `
 
-exports[`test/basic.js TAP extends-array-empty > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > extends-array-empty > must match snapshot 1`] = `
 Object {
   "all": true,
   "cwd": "package-root:;test/fixtures/extends-array-empty",
 }
 `
 
-exports[`test/basic.js TAP extends-cwd > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > extends-cwd > must match snapshot 1`] = `
 Object {
   "all": true,
   "cwd": "package-root:;test/fixtures/extends-cwd",
 }
 `
 
-exports[`test/basic.js TAP found package.json cwd from subdir > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > found package.json cwd from subdir > must match snapshot 1`] = `
 Object {
   "all": false,
   "cwd": "package-root:;test/fixtures/nycrc-json",
 }
 `
 
-exports[`test/basic.js TAP no package.json > explicit .nycrc 1`] = `
+exports[`test/basic.js > TAP > no package.json > explicit .nycrc 1`] = `
 Object {
   "all": false,
   "cwd": "root:;",
 }
 `
 
-exports[`test/basic.js TAP no package.json > no config 1`] = `
+exports[`test/basic.js > TAP > no package.json > no config 1`] = `
 Object {
   "cwd": "root:;",
 }
 `
 
-exports[`test/basic.js TAP no-config-file > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > no-config-file > must match snapshot 1`] = `
 Object {
   "all": true,
   "cwd": "package-root:;test/fixtures/no-config-file",
 }
 `
 
-exports[`test/basic.js TAP nyc-config-async > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > nyc-config-async > must match snapshot 1`] = `
 Object {
   "all": false,
   "cwd": "package-root:;test/fixtures/nyc-config-async",
 }
 `
 
-exports[`test/basic.js TAP nyc-config-cjs > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > nyc-config-cjs > must match snapshot 1`] = `
 Object {
   "all": false,
   "cwd": "package-root:;test/fixtures/nyc-config-cjs",
 }
 `
 
-exports[`test/basic.js TAP nyc-config-js > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > nyc-config-js > must match snapshot 1`] = `
 Object {
   "all": false,
   "cwd": "package-root:;test/fixtures/nyc-config-js",
 }
 `
 
-exports[`test/basic.js TAP nyc-config-js-type-module > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > nyc-config-js-type-module > must match snapshot 1`] = `
 Object {
   "all": false,
   "cwd": "package-root:;test/fixtures/nyc-config-js-type-module",
 }
 `
 
-exports[`test/basic.js TAP nyc-config-mjs > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > nyc-config-mjs > must match snapshot 1`] = `
 Object {
   "all": false,
   "cwd": "package-root:;test/fixtures/nyc-config-mjs",
 }
 `
 
-exports[`test/basic.js TAP nycrc-json > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > nycrc-json > must match snapshot 1`] = `
 Object {
   "all": false,
   "cwd": "package-root:;test/fixtures/nycrc-json",
 }
 `
 
-exports[`test/basic.js TAP nycrc-no-ext > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > nycrc-no-ext > must match snapshot 1`] = `
 Object {
   "all": false,
   "cwd": "package-root:;test/fixtures/nycrc-no-ext",
 }
 `
 
-exports[`test/basic.js TAP nycrc-yaml > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > nycrc-yaml > must match snapshot 1`] = `
 Object {
   "all": false,
   "cwd": "package-root:;test/fixtures/nycrc-yaml",
 }
 `
 
-exports[`test/basic.js TAP nycrc-yml > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > nycrc-yml > must match snapshot 1`] = `
 Object {
   "all": false,
   "cwd": "package-root:;test/fixtures/nycrc-yml",
 }
 `
 
-exports[`test/basic.js TAP package-lock-cwd > must match snapshot 1`] = `
+exports[`test/basic.js > TAP > package-lock-cwd > must match snapshot 1`] = `
 Object {
   "cwd": "package-root:;test/fixtures/package-lock-cwd/subdir",
 }

--- a/tap-snapshots/test/env-nyc-cwd.js.test.cjs
+++ b/tap-snapshots/test/env-nyc-cwd.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/process-cwd.js TAP process-cwd > must match snapshot 1`] = `
+exports[`test/env-nyc-cwd.js > TAP > env-nyc-cwd > must match snapshot 1`] = `
 Object {
   "all": true,
   "cwd": "package-root:;test/fixtures/no-config-file",

--- a/tap-snapshots/test/process-cwd.js.test.cjs
+++ b/tap-snapshots/test/process-cwd.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/env-nyc-cwd.js TAP env-nyc-cwd > must match snapshot 1`] = `
+exports[`test/process-cwd.js > TAP > process-cwd > must match snapshot 1`] = `
 Object {
   "all": true,
   "cwd": "package-root:;test/fixtures/no-config-file",


### PR DESCRIPTION
Fixes #22
Closes #13

This is an alternative to #23, which includes updates to `xo` and `tap` to allow for `npm test` to succeed. Rather than updating the `js-yaml` dependency, it's here replaced by `yaml`.

A very simple Github Actions script is included to run `npm install` and `npm test` on PRs and default branch commits.

The behaviour change regarding JSON file parsing discussed in #13 is not included here.