### PR TITLE
chore: bump js-yaml to ^4.1.1 (security)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"camelcase": "^5.3.1",
 		"find-up": "^4.1.0",
 		"get-package-type": "^0.1.0",
-		"js-yaml": "^3.13.1",
+		"js-yaml": "^4.1.1",
 		"resolve-from": "^5.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Bumps js-yaml to ^4.1.1 to address a security advisory in older js-yaml versions (3.x). This package is a dependency of many tooling chains; upgrading here will remove the vulnerable version from transitive dependency trees. I updated package.json and ran tests locally. Happy to adjust if you prefer a different target version.